### PR TITLE
DO-24 Upgrade Craft to 2.6.2983

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Craft CMS Base Image
 
+### 0.1.0 Unreleased
+
+* [DO-24] Upgrade Craft patch version to 2.6.2983.
+
 ### 0.0.3
 
 * [TT-2626] Improvements in 3 areas: bower, git as a composer package

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7.0-apache
 
-ARG CRAFT_ARCHIVE_URL=https://download.craftcdn.com/craft/2.6/2.6.2978/Craft-2.6.2978.zip
+ARG CRAFT_ARCHIVE_URL=https://download.craftcdn.com/craft/2.6/2.6.2983/Craft-2.6.2983.zip
 
 ARG NODE_SOURCE_VERSION=node_6.x
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Craft CMS Base Image
 
+# Version mapping
+
+`sealink/craft:0.1` is mapped to Craft CMS 2.6.x.  You can expect it to contain
+the latest Craft patch version of 2.6.
+
 ## Development Environment
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Craft CMS Base Image
 
-# Version mapping
+## Craft Version
 
 `sealink/craft:0.1` is mapped to Craft CMS 2.6.x.  You can expect it to contain
 the latest Craft patch version of 2.6.


### PR DESCRIPTION
# Why?

Besides upgrading Craft, the main change this PR is proposing is to publish the minor version to `sealink/craft:0.1` so all the Craft sites can remain using it until we move to Craft 3.  This will eliminate the need for create PRs for the individual Craft sites.  Please help making sure the README file is concise.