### PR TITLE
Increase the PHP uplaod size limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### 0.1.1
 
+* [TT-2756] Increase the PHP uplaod size limit
+
+### 0.1.1
+
 * [DO-24] Remove the unused Zscaler certificate.
 
 ### 0.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ ENV LANG C.UTF-8
 
 WORKDIR /app
 
+COPY config/php /usr/local/etc/php/conf.d
+
 COPY config/craft.conf /etc/apache2/conf-enabled
 
 COPY bin /container-scripts

--- a/config/php/upload_size.ini
+++ b/config/php/upload_size.ini
@@ -1,0 +1,2 @@
+upload_max_filesize=16M
+post_max_size=16M


### PR DESCRIPTION
# Why?

So that we can upload images bigger than 2MiB.