### PR TITLE
Re-add token param setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Craft CMS Base Image
 
+### 0.1.3
+
+* [DSM-343] Fix token param setting
+
 ### 0.1.2
 
 * [TT-2756] Increase the PHP upload size limit

--- a/config/craft/general.php
+++ b/config/craft/general.php
@@ -13,6 +13,7 @@ return array_merge(
     'generateTransformsBeforePageLoad' => true,
     'sendPoweredByHeader' => false,
     'phpSessionName' => 'sid',
+    'tokenParam' => 'craft_token',
   ),
   require(__DIR__ . '/overrides/general.php')
 );


### PR DESCRIPTION
The new Craft base had removed the tokenParam setting that was previously set in the general config.

Currently resulting in a 404:
https://www.kangarooislandodysseys.com.au/reset_password/confirm?token=abc123

https://craftcms.com/docs/config-settings#tokenParam

The setting previously: https://bitbucket.org/team-sealink/one-sealink/commits/368bf6a83b833e823bbe23612aae8fbb8c596920#Lconfig/general.phpF35