### PR TITLE
DO-68 Upgrade to Craft 2.6.2988

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [DO-54] Add the data migration task
 * [DO-54] Automate data migration synchronisation
 * [DO-61] Upgrade Craft to version 2.6.2987.
+* [DO-68] Upgrade Craft to version 2.6.2988.
 
 ### 0.1.4
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7.0-apache
 
-ARG CRAFT_ARCHIVE_URL=https://download.craftcdn.com/craft/2.6/2.6.2987/Craft-2.6.2987.zip
+ARG CRAFT_ARCHIVE_URL=https://download.craftcdn.com/craft/2.6/2.6.2987/Craft-2.6.2988.zip
 
 ARG NODE_SOURCE_VERSION=node_6.x
 


### PR DESCRIPTION
# Why?

To keep our Craft sites up-to-date: https://craftcms.com/changelog.