### PR TITLE
DC-438 Use only routes that have slash ending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Craft CMS Base Image
 
+### Unreleased
+
+* [DC-438] Use only routes that have slash ending
+
 ### 0.1.5
 
 * [DO-53] Stop Craft from downgrading plugins silently

--- a/bin/setup/craft/main
+++ b/bin/setup/craft/main
@@ -30,8 +30,6 @@ unzip "$CRAFT_ARCHIVE"
 rm -v "$CRAFT_ARCHIVE"
 
 mv -v craft /app
-mkdir -v /app/public
-mv -v public/htaccess /app/public/.htaccess
 rm -vRf "$CRAFT_ARCHIVE_DIR"
 
 mv -v /app/craft/app/etc/config/common{,_original}.php

--- a/src/public/.htaccess
+++ b/src/public/.htaccess
@@ -6,8 +6,11 @@
   RewriteCond %{REQUEST_URI} ^/(favicon\.ico|apple-touch-icon.*\.png)$ [NC]
   RewriteRule .* - [L]
 
-  RewriteCond %{REQUEST_URI} /$
-  RewriteRule (.+)/+$ %{REQUEST_SCHEME}://%{HTTP_HOST}/$1 [R=301,L]
-
+  RewriteCond %{REQUEST_URI} [^/]$
   RewriteRule (.+) index.php?p=$1 [QSA,L]
+
+  RewriteCond %{HTTP:X-Forwarded-Proto} ^https$
+  RewriteRule (.+)/+$ %{HTTP:X-Forwarded-Proto}://%{HTTP_HOST}/$1 [R=301,L]
+
+  RewriteRule (.+)/+$ %{REQUEST_SCHEME}://%{HTTP_HOST}/$1 [R=301,L]
 </IfModule>

--- a/src/public/.htaccess
+++ b/src/public/.htaccess
@@ -6,8 +6,8 @@
   RewriteCond %{REQUEST_URI} ^/(favicon\.ico|apple-touch-icon.*\.png)$ [NC]
   RewriteRule .* - [L]
 
-  RewriteCond %{REQUEST_URI} [^/]$
-  RewriteRule .* %{REQUEST_URI}/ [R=301,L]
+  RewriteCond %{REQUEST_URI} /$
+  RewriteRule ^(.*)/+$ $1 [R=301,L]
 
   RewriteRule (.+) index.php?p=$1 [QSA,L]
 </IfModule>

--- a/src/public/.htaccess
+++ b/src/public/.htaccess
@@ -1,0 +1,13 @@
+<IfModule mod_rewrite.c>
+  RewriteEngine On
+
+  RewriteCond %{REQUEST_FILENAME} -f [OR]
+  RewriteCond %{REQUEST_FILENAME} -d [OR]
+  RewriteCond %{REQUEST_URI} ^/(favicon\.ico|apple-touch-icon.*\.png)$ [NC]
+  RewriteRule .* - [L]
+
+  RewriteCond %{REQUEST_URI} [^/]$
+  RewriteRule .* %{REQUEST_URI}/ [R=301,L]
+
+  RewriteRule (.+) index.php?p=$1 [QSA,L]
+</IfModule>

--- a/src/public/.htaccess
+++ b/src/public/.htaccess
@@ -7,7 +7,7 @@
   RewriteRule .* - [L]
 
   RewriteCond %{REQUEST_URI} /$
-  RewriteRule (.+)/+$ /$1 [R=301,L]
+  RewriteRule (.+)/+$ %{REQUEST_SCHEME}://%{HTTP_HOST}/$1 [R=301,L]
 
   RewriteRule (.+) index.php?p=$1 [QSA,L]
 </IfModule>

--- a/src/public/.htaccess
+++ b/src/public/.htaccess
@@ -12,5 +12,5 @@
   RewriteCond %{HTTP:X-Forwarded-Proto} ^https$
   RewriteRule (.+)/+$ %{HTTP:X-Forwarded-Proto}://%{HTTP_HOST}/$1 [R=301,L]
 
-  RewriteRule (.+)/+$ %{REQUEST_SCHEME}://%{HTTP_HOST}/$1 [R=301,L]
+  RewriteRule (.+)/+$ /$1 [R=301,L]
 </IfModule>

--- a/src/public/.htaccess
+++ b/src/public/.htaccess
@@ -7,7 +7,7 @@
   RewriteRule .* - [L]
 
   RewriteCond %{REQUEST_URI} /$
-  RewriteRule ^(.*)/+$ $1 [R=301,L]
+  RewriteRule (.+)/+$ /$1 [R=301,L]
 
   RewriteRule (.+) index.php?p=$1 [QSA,L]
 </IfModule>


### PR DESCRIPTION
# Why?

So that we won't have duplicate entries in our SEO analysis.

Please refer to the story for the reviewers who have access to our issue tracking system.

# Testing

I will be testing this with a Craft project of ours.