### PR TITLE
DC-576 Upgrade Craft to version 2.6.2991

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 
 * [DO-75] Correct the spelling
+* [DC-576] Upgrade Craft to version 2.6.2991
 
 ### 0.1.6
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7.0-apache
 
-ARG CRAFT_ARCHIVE_URL=https://download.craftcdn.com/craft/2.6/2.6.2988/Craft-2.6.2988.zip
+ARG CRAFT_ARCHIVE_URL=https://download.craftcdn.com/craft/2.6/2.6.2991/Craft-2.6.2991.zip
 
 ARG NODE_SOURCE_VERSION=node_6.x
 

--- a/bin/setup/craft/main
+++ b/bin/setup/craft/main
@@ -30,6 +30,7 @@ unzip "$CRAFT_ARCHIVE"
 rm -v "$CRAFT_ARCHIVE"
 
 mv -v craft /app
+cd
 rm -vRf "$CRAFT_ARCHIVE_DIR"
 
 mv -v /app/craft/app/etc/config/common{,_original}.php


### PR DESCRIPTION
# Why?

To upgrade to the latest patch version.

# Testing

Tested in our next environment.