### PR TITLE
DO-101 Upgrade Craft to version 2.6.2994

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Craft CMS Base Image
 
+### Unreleased
+
+* [DO-101] Upgrade Craft to version 2.6.2994
+
 ### 0.1.7
 
 * [DO-75] Correct the spelling

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7.0-apache
 
-ARG CRAFT_ARCHIVE_URL=https://download.craftcdn.com/craft/2.6/2.6.2991/Craft-2.6.2991.zip
+ARG CRAFT_ARCHIVE_URL=https://download.craftcdn.com/craft/2.6/2.6.2994/Craft-2.6.2994.zip
 
 ARG NODE_SOURCE_VERSION=node_6.x
 


### PR DESCRIPTION
# Why?

@dwaring wrote:

>> Craft CMS 2.6.2994:
>> Fixed a bug where front-end URLs that were generated in the Control Panel were not getting trailing slashes if the addTrailingSlashesToUrls config setting was enabled.

> :arrow_up: I think this may have got us in the past